### PR TITLE
Ensure sanitized filenames stay within length limit

### DIFF
--- a/src/main/java/com/autopost/FilenameUtil.java
+++ b/src/main/java/com/autopost/FilenameUtil.java
@@ -5,7 +5,9 @@ public class FilenameUtil {
   public static String sanitizeBase(String s){
     String n=Normalizer.normalize(s, Normalizer.Form.NFD).replaceAll("[^\\p{ASCII}]","");
     n=n.replaceAll("[^A-Za-z0-9._-]+","_").replaceAll("_+","_").replaceAll("(^_|_$)","");
-    if(n.length()>60) n=n.substring(0,60); if(!n.toLowerCase().endsWith(".mp4")) n+=".mp4"; return n;
+    if(!n.toLowerCase().endsWith(".mp4")) n+=".mp4";
+    if(n.length()>60) n=n.substring(0,56)+".mp4";
+    return n;
   }
   public static String buildName(String collab,String type,int i){
     String date=LocalDate.now().format(D); String base=(collab==null||collab.isBlank()? "clip": collab)+"_"+type+"_"+String.format("%02d",i);


### PR DESCRIPTION
## Summary
- prevent `FilenameUtil.sanitizeBase` from producing names longer than 60 characters by trimming before appending `.mp4`

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: The following artifacts could not be resolved: org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 (absent): Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e3ee88e5c8330b8a89996298de130