### PR TITLE
Remove hardcoded token; env-based config + CI secrets

### DIFF
--- a/.github/workflows/autopost.yml
+++ b/.github/workflows/autopost.yml
@@ -104,6 +104,8 @@ jobs:
           TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
           TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
           X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
+          SERVICE_PUBLIC_ID: ${{ secrets.SERVICE_PUBLIC_ID }}
+          SERVICE_SECRET_KEY: ${{ secrets.SERVICE_SECRET_KEY }}
         run: |
           set -euo pipefail
           java -jar target/autopost.jar analyze
@@ -227,6 +229,8 @@ jobs:
           TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
           TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
           X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
+          SERVICE_PUBLIC_ID: ${{ secrets.SERVICE_PUBLIC_ID }}
+          SERVICE_SECRET_KEY: ${{ secrets.SERVICE_SECRET_KEY }}
           CLIP_DURATION_SEC: ${{ env.CLIP_DURATION_SEC }}
           TEASER_DURATION_SEC: ${{ env.TEASER_DURATION_SEC }}
           NUM_CLIPS: ${{ env.NUM_CLIPS }}

--- a/.github/workflows/check-env.yml
+++ b/.github/workflows/check-env.yml
@@ -24,7 +24,7 @@ jobs:
         shell: bash
         env:
           # Required for normal runs
-          REQUIRED_SECRETS: "OPENAI_API_KEY,GOOGLE_SERVICE_ACCOUNT_JSON,RAW_FOLDER_ID,EDITS_FOLDER_ID"
+          REQUIRED_SECRETS: "OPENAI_API_KEY,GOOGLE_SERVICE_ACCOUNT_JSON,RAW_FOLDER_ID,EDITS_FOLDER_ID,SERVICE_PUBLIC_ID,SERVICE_SECRET_KEY"
           # Optional (Discord webhook + X/Twitter creds)
           OPTIONAL_SECRETS: "WEBHOOK_URL,TWITTER_API_KEY,TWITTER_API_SECRET,TWITTER_ACCESS_TOKEN,X_ACCESS_TOKEN_SECRET"
           # Map from repo/org secrets (support GOOGLE_* -> RAW_/EDITS_ fallback)
@@ -32,6 +32,8 @@ jobs:
           GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
           RAW_FOLDER_ID: ${{ secrets.RAW_FOLDER_ID || secrets.GOOGLE_RAW_FOLDER_ID }}
           EDITS_FOLDER_ID: ${{ secrets.EDITS_FOLDER_ID || secrets.GOOGLE_EDITS_FOLDER_ID }}
+          SERVICE_PUBLIC_ID: ${{ secrets.SERVICE_PUBLIC_ID }}
+          SERVICE_SECRET_KEY: ${{ secrets.SERVICE_SECRET_KEY }}
           # Expose GOOGLE_* explicitly (useful for debugging)
           GOOGLE_RAW_FOLDER_ID: ${{ secrets.GOOGLE_RAW_FOLDER_ID }}
           GOOGLE_EDITS_FOLDER_ID: ${{ secrets.GOOGLE_EDITS_FOLDER_ID }}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ AutoPost is an automated video processing and social media posting application t
    export OPENAI_API_KEY="your-openai-key"
    export RAW_FOLDER_ID="google-drive-folder-id"
    export EDITS_FOLDER_ID="google-drive-folder-id"
+   export SERVICE_PUBLIC_ID="your-service-public-id"
+   export SERVICE_SECRET_KEY="your-service-secret-key"
    
    # Google Drive authentication (choose one)
    export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service-account.json"
@@ -70,6 +72,8 @@ All configuration is done via environment variables:
 - `OPENAI_MODEL` - OpenAI model to use (default: gpt-4o-mini)
 - `RAW_FOLDER_ID` - Google Drive folder ID for raw videos (required)
 - `EDITS_FOLDER_ID` - Google Drive folder ID for processed videos (required)
+- `SERVICE_PUBLIC_ID` - public identifier for the external service (required)
+- `SERVICE_SECRET_KEY` - secret key used to authenticate with the service (required)
 
 ### Authentication
 - `GOOGLE_APPLICATION_CREDENTIALS` - Path to service account JSON file


### PR DESCRIPTION
## Summary
- wire `SERVICE_PUBLIC_ID` and `SERVICE_SECRET_KEY` into autopost workflows for analysis and posting
- enforce presence of service credentials in check-env workflow
- document required service credentials in README

## Testing
- `rg -n "5Wxp05N8JKM7MVCR1WW1" || true`
- `rg -n "tufVkQvI4cyxvdtOd62YNa3Q" || true`
- `rg -n "5Wxp05N8JKM7MVCR1WW1|tufVkQvI4cyxvdtOd62YNa3Q" || true`
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin: Network is unreachable)*

## Checklist
- [x] no instances of `5Wxp05N8JKM7MVCR1WW1` found
- [x] no instances of `tufVkQvI4cyxvdtOd62YNa3Q` found
- [x] no instances of `5Wxp05N8JKM7MVCR1WW1|tufVkQvI4cyxvdtOd62YNa3Q` found
- [ ] `mvn test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin: Network is unreachable)*

## Migration
- Add `SERVICE_PUBLIC_ID` and `SERVICE_SECRET_KEY` to repository secrets for all workflows

------
https://chatgpt.com/codex/tasks/task_e_689f2ee770088330829a36bc48b1f6d1