### PR TITLE
Remove hardcoded token; env-based config + CI secrets

### DIFF
--- a/.github/workflows/autopost.yml
+++ b/.github/workflows/autopost.yml
@@ -104,6 +104,8 @@ jobs:
           TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
           TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
           X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
+          SERVICE_PUBLIC_ID: ${{ secrets.SERVICE_PUBLIC_ID }}
+          SERVICE_SECRET_KEY: ${{ secrets.SERVICE_SECRET_KEY }}
         run: |
           set -euo pipefail
           java -jar target/autopost.jar analyze
@@ -227,6 +229,8 @@ jobs:
           TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
           TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
           X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
+          SERVICE_PUBLIC_ID: ${{ secrets.SERVICE_PUBLIC_ID }}
+          SERVICE_SECRET_KEY: ${{ secrets.SERVICE_SECRET_KEY }}
           CLIP_DURATION_SEC: ${{ env.CLIP_DURATION_SEC }}
           TEASER_DURATION_SEC: ${{ env.TEASER_DURATION_SEC }}
           NUM_CLIPS: ${{ env.NUM_CLIPS }}

--- a/.github/workflows/check-env.yml
+++ b/.github/workflows/check-env.yml
@@ -24,7 +24,7 @@ jobs:
         shell: bash
         env:
           # Required for normal runs
-          REQUIRED_SECRETS: "OPENAI_API_KEY,GOOGLE_SERVICE_ACCOUNT_JSON,RAW_FOLDER_ID,EDITS_FOLDER_ID"
+          REQUIRED_SECRETS: "OPENAI_API_KEY,GOOGLE_SERVICE_ACCOUNT_JSON,RAW_FOLDER_ID,EDITS_FOLDER_ID,SERVICE_PUBLIC_ID,SERVICE_SECRET_KEY"
           # Optional (Discord webhook + X/Twitter creds)
           OPTIONAL_SECRETS: "WEBHOOK_URL,TWITTER_API_KEY,TWITTER_API_SECRET,TWITTER_ACCESS_TOKEN,X_ACCESS_TOKEN_SECRET"
           # Map from repo/org secrets (support GOOGLE_* -> RAW_/EDITS_ fallback)
@@ -32,6 +32,8 @@ jobs:
           GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
           RAW_FOLDER_ID: ${{ secrets.RAW_FOLDER_ID || secrets.GOOGLE_RAW_FOLDER_ID }}
           EDITS_FOLDER_ID: ${{ secrets.EDITS_FOLDER_ID || secrets.GOOGLE_EDITS_FOLDER_ID }}
+          SERVICE_PUBLIC_ID: ${{ secrets.SERVICE_PUBLIC_ID }}
+          SERVICE_SECRET_KEY: ${{ secrets.SERVICE_SECRET_KEY }}
           # Expose GOOGLE_* explicitly (useful for debugging)
           GOOGLE_RAW_FOLDER_ID: ${{ secrets.GOOGLE_RAW_FOLDER_ID }}
           GOOGLE_EDITS_FOLDER_ID: ${{ secrets.GOOGLE_EDITS_FOLDER_ID }}

--- a/github_workflows_autopost-llm.yml
+++ b/github_workflows_autopost-llm.yml
@@ -9,23 +9,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Install ffmpeg
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
-      
+
       - uses: actions/setup-java@v4
-        with: 
+        with:
           distribution: temurin
           java-version: "17"
-      
+
       - name: Build
         run: mvn -q -DskipTests package
-      
+
       - name: Write service account file
         run: echo "$GOOGLE_SERVICE_ACCOUNT_JSON" > sa.json
         env:
           GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
-      
+
       - name: Run Application
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -36,12 +36,14 @@ jobs:
           TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
           TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
           X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
+          SERVICE_PUBLIC_ID: ${{ secrets.SERVICE_PUBLIC_ID }}
+          SERVICE_SECRET_KEY: ${{ secrets.SERVICE_SECRET_KEY }}
         run: |
           java -jar target/autopost.jar &
           APP_PID=$!
           sleep 300  # Run for 5 minutes to allow scheduling
           kill $APP_PID || true
-      
+
       - name: Commit state files
         run: |
           git config user.name "autopost-bot"


### PR DESCRIPTION
## Summary
- wire service credentials through GitHub workflow secrets so runtime config isn't hardcoded
- extend env check workflow to require service credentials

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1; Network is unreachable)*
- `rg --no-ignore --hidden --fixed-strings '5Wxp05N8JKM7MVCR1WW1|tufVkQvI4cyxvdtOd62YNa3Q'`
- `rg --no-ignore --hidden --fixed-strings '5Wxp05N8JKM7MVCR1WW1'`
- `rg --no-ignore --hidden --fixed-strings 'tufVkQvI4cyxvdtOd62YNa3Q'`

## Checklist
- [x] `rg --no-ignore --hidden --fixed-strings '5Wxp05N8JKM7MVCR1WW1|tufVkQvI4cyxvdtOd62YNa3Q'` → no results
- [x] `rg --no-ignore --hidden --fixed-strings '5Wxp05N8JKM7MVCR1WW1'` → no results
- [x] `rg --no-ignore --hidden --fixed-strings 'tufVkQvI4cyxvdtOd62YNa3Q'` → no results

## Commands to Run Locally
1. `mvn -q test`
2. `rg --no-ignore --hidden --fixed-strings '5Wxp05N8JKM7MVCR1WW1|tufVkQvI4cyxvdtOd62YNa3Q'`

## Migration Notes
- Define `SERVICE_PUBLIC_ID` and `SERVICE_SECRET_KEY` in repository secrets for workflows.


------
https://chatgpt.com/codex/tasks/task_e_689f302be0d48330b6992f4f3f67e1aa