### PR TITLE
Remove hardcoded token; env-based config + CI secrets

### DIFF
--- a/.github/workflows/check-env.yml
+++ b/.github/workflows/check-env.yml
@@ -24,7 +24,7 @@ jobs:
         shell: bash
         env:
           # Required for normal runs
-          REQUIRED_SECRETS: "OPENAI_API_KEY,GOOGLE_SERVICE_ACCOUNT_JSON,RAW_FOLDER_ID,EDITS_FOLDER_ID"
+          REQUIRED_SECRETS: "OPENAI_API_KEY,GOOGLE_SERVICE_ACCOUNT_JSON,RAW_FOLDER_ID,EDITS_FOLDER_ID,SERVICE_PUBLIC_ID,SERVICE_SECRET_KEY"
           # Optional (Discord webhook + X/Twitter creds)
           OPTIONAL_SECRETS: "WEBHOOK_URL,TWITTER_API_KEY,TWITTER_API_SECRET,TWITTER_ACCESS_TOKEN,X_ACCESS_TOKEN_SECRET"
           # Map from repo/org secrets (support GOOGLE_* -> RAW_/EDITS_ fallback)
@@ -32,6 +32,8 @@ jobs:
           GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
           RAW_FOLDER_ID: ${{ secrets.RAW_FOLDER_ID || secrets.GOOGLE_RAW_FOLDER_ID }}
           EDITS_FOLDER_ID: ${{ secrets.EDITS_FOLDER_ID || secrets.GOOGLE_EDITS_FOLDER_ID }}
+          SERVICE_PUBLIC_ID: ${{ secrets.SERVICE_PUBLIC_ID }}
+          SERVICE_SECRET_KEY: ${{ secrets.SERVICE_SECRET_KEY }}
           # Expose GOOGLE_* explicitly (useful for debugging)
           GOOGLE_RAW_FOLDER_ID: ${{ secrets.GOOGLE_RAW_FOLDER_ID }}
           GOOGLE_EDITS_FOLDER_ID: ${{ secrets.GOOGLE_EDITS_FOLDER_ID }}


### PR DESCRIPTION
## Summary
- ensure `check-env` workflow verifies `SERVICE_PUBLIC_ID` and `SERVICE_SECRET_KEY`
- source service credentials from GitHub Secrets instead of hardcoding

## Testing
- `rg -n "5Wxp05N8JKM7MVCR1WW1\|tufVkQvI4cyxvdtOd62YNa3Q" -l || true`
- `rg -n "5Wxp05N8JKM7MVCR1WW1" -l || true`
- `rg -n "tufVkQvI4cyxvdtOd62YNa3Q" -l || true`
- `mvn -q test` *(fails: Could not transfer artifact ... Network is unreachable)*

## Checklist
- [x] no occurrences of the sensitive token or its halves
- [ ] `mvn -q test` *(fails: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_689f5a2b5cd883308f60b6fc9a06c68d