### PR TITLE
Remove hardcoded token; env-based config + CI secrets

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -1,0 +1,84 @@
+name: Build & Publish (Maven + GH Packages)
+
+on:
+  push:
+    branches: [ main ]
+    tags: ["v*"]          # e.g. v1.0.0
+  pull_request:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      MAVEN_OPTS: >-
+        -Djava.net.preferIPv4Stack=true
+        -Dmaven.wagon.http.retryHandler.count=10
+        -Dmaven.wagon.http.pool=false
+        -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
+        -Dhttp.keepAlive=false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21 + Maven auth
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+
+      - name: Write Maven settings (mirror + timeouts)
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml << 'XML'
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+            <mirrors>
+              <!-- Force central to official endpoint to avoid flaky DNS -->
+              <mirror>
+                <id>central-mirror</id>
+                <name>Maven Central (Mirror)</name>
+                <url>https://repo.maven.apache.org/maven2</url>
+                <mirrorOf>central</mirrorOf>
+              </mirror>
+            </mirrors>
+            <profiles>
+              <profile>
+                <id>ci-wagon</id>
+                <properties>
+                  <maven.wagon.http.retryHandler.count>10</maven.wagon.http.retryHandler.count>
+                  <maven.wagon.http.pool>false</maven.wagon.http.pool>
+                  <maven.wagon.httpconnectionManager.ttlSeconds>25</maven.wagon.httpconnectionManager.ttlSeconds>
+                </properties>
+              </profile>
+            </profiles>
+            <activeProfiles>
+              <activeProfile>ci-wagon</activeProfile>
+            </activeProfiles>
+          </settings>
+          XML
+
+      - name: Build & Test
+        run: mvn -B -U -q clean test -Djava.net.preferIPv4Stack=true
+
+      - name: Package (non-PR)
+        if: ${{ github.event_name != 'pull_request' }}
+        run: mvn -B -U -q -DskipTests package -Djava.net.preferIPv4Stack=true
+
+      - name: Set version from tag (vX.Y.Z)
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: mvn -B -q versions:set -DnewVersion="${GITHUB_REF_NAME#v}" -DgenerateBackupPoms=false
+
+      - name: Deploy to GitHub Packages
+        if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mvn -B -U -q -DskipTests deploy -Djava.net.preferIPv4Stack=true

--- a/pom.xml
+++ b/pom.xml
@@ -1,22 +1,95 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.autopost</groupId><artifactId>autopost</artifactId><version>1.1.0</version><name>AutoPost</name>
-  <properties><maven.compiler.source>17</maven.compiler.source><maven.compiler.target>17</maven.compiler.target></properties>
+
+  <groupId>com.autopost</groupId>
+  <artifactId>autopost</artifactId>
+  <version>1.1.0</version>
+  <name>AutoPost</name>
+
+  <properties>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>central</id>
+      <name>Maven Central</name>
+      <url>https://repo1.maven.org/maven2/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages - tylerblakex-netizen/AutoPost</name>
+      <url>https://maven.pkg.github.com/tylerblakex-netizen/AutoPost</url>
+    </repository>
+    <snapshotRepository>
+      <id>github</id>
+      <name>GitHub Packages (Snapshots) - tylerblakex-netizen/AutoPost</name>
+      <url>https://maven.pkg.github.com/tylerblakex-netizen/AutoPost</url>
+    </snapshotRepository>
+  </distributionManagement>
+
   <dependencies>
     <!-- Spring Boot Starter -->
-    <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-web</artifactId><version>3.2.0</version></dependency>
-    <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-validation</artifactId><version>3.2.0</version></dependency>
-    <dependency><groupId>jakarta.annotation</groupId><artifactId>jakarta.annotation-api</artifactId><version>2.1.1</version></dependency>
-    
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>3.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+      <version>3.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <version>2.1.1</version>
+    </dependency>
+
     <!-- Existing dependencies -->
-    <dependency><groupId>com.google.apis</groupId><artifactId>google-api-services-drive</artifactId><version>v3-rev20250723-2.0.0</version></dependency>
-    <dependency><groupId>com.google.auth</groupId><artifactId>google-auth-library-oauth2-http</artifactId><version>1.23.0</version></dependency>
-    <dependency><groupId>com.squareup.okhttp3</groupId><artifactId>okhttp</artifactId><version>4.12.0</version></dependency>
-    <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
-    <dependency><groupId>org.twitter4j</groupId><artifactId>twitter4j-core</artifactId><version>4.0.7</version></dependency>
-    <dependency><groupId>org.threeten</groupId><artifactId>threetenbp</artifactId><version>1.6.8</version></dependency>
-    
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-drive</artifactId>
+      <version>v3-rev20250723-2.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+      <version>1.23.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <version>4.12.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.17.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.twitter4j</groupId>
+      <artifactId>twitter4j-core</artifactId>
+      <version>4.0.7</version>
+    </dependency>
+    <dependency>
+      <groupId>org.threeten</groupId>
+      <artifactId>threetenbp</artifactId>
+      <version>1.6.8</version>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -25,6 +98,7 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
   <build>
     <plugins>
       <plugin>
@@ -33,12 +107,25 @@
         <version>3.2.5</version>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId><artifactId>maven-shade-plugin</artifactId><version>3.5.0</version>
-        <executions><execution><phase>package</phase><goals><goal>shade</goal></goals>
-          <configuration><transformers>
-            <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-              <mainClass>com.autopost.App</mainClass></transformer></transformers><finalName>autopost</finalName></configuration>
-        </execution></executions>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>com.autopost.App</mainClass>
+                </transformer>
+              </transformers>
+              <finalName>autopost</finalName>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
## Summary
- harden Maven GitHub Actions workflow with IPv4 stack, retries, and central mirror
- confirm no secret tokens in repo; configuration relies on env vars and GitHub Secrets

## Checklist
- [x] `rg -n "5Wxp05N8JKM7MVCR1WW1|tufVkQvI4cyxvdtOd62YNa3Q" || true`
- [x] `rg -n "5Wxp05N8JKM7MVCR1WW1" || true`
- [x] `rg -n "tufVkQvI4cyxvdtOd62YNa3Q" || true`
- [ ] `mvn -q -e -Djava.net.preferIPv4Stack=true test` *(fails: Network is unreachable)*

## Commands to Run Locally
- `mvn -q -e -Djava.net.preferIPv4Stack=true test`

## Migration Notes
- Ensure `SERVICE_PUBLIC_ID` and `SERVICE_SECRET_KEY` are provided via environment variables or platform secrets.


------
https://chatgpt.com/codex/tasks/task_e_689f8138d98483309ea88f8d400e7b3f