### PR TITLE
Remove hardcoded token; env-based config + CI secrets

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -2,8 +2,8 @@ name: Build & Publish (Gradle + GH Packages)
 
 on:
   push:
-    branches: [ main ]
-    tags: ["v*"]    # e.g. v1.0.0
+    branches: [ "main" ]
+    tags: ["v*"]
   pull_request:
 
 permissions:
@@ -13,9 +13,23 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    # Provide placeholders on PRs so the build/tests can run without secrets.
+    # On main/tags, we still require real secrets.
     env:
-      SERVICE_PUBLIC_ID: ${{ secrets.SERVICE_PUBLIC_ID }}
-      SERVICE_SECRET_KEY: ${{ secrets.SERVICE_SECRET_KEY }}
+      # Secrets (use placeholders if absent so PR builds don't explode)
+      SERVICE_PUBLIC_ID: ${{ secrets.SERVICE_PUBLIC_ID != '' && secrets.SERVICE_PUBLIC_ID || 'dev-placeholder' }}
+      SERVICE_SECRET_KEY: ${{ secrets.SERVICE_SECRET_KEY != '' && secrets.SERVICE_SECRET_KEY || 'dev-placeholder' }}
+
+      # Network & Gradle stability
+      GRADLE_OPTS: >-
+        -Dorg.gradle.jvmargs="-Xmx2g -Djava.net.preferIPv4Stack=true"
+        -Dorg.gradle.parallel=true
+        -Dorg.gradle.caching=true
+        -Dorg.gradle.daemon=false
+      MAVEN_OPTS: >-
+        -Djava.net.preferIPv4Stack=true
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,15 +43,48 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 8.9
           cache-disabled: true
+          gradle-version: 8.9
 
-      - name: Build (unit + integration tests)
-        run: gradle build --no-daemon
+      # Only fail fast on main/tags (release surfaces).
+      - name: Fail fast if required secrets are missing (main/tags only)
+        if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
+        run: |
+          miss=""
+          [ -z "${SERVICE_PUBLIC_ID}" ] && miss="${miss} SERVICE_PUBLIC_ID"
+          [ -z "${SERVICE_SECRET_KEY}" ] && miss="${miss} SERVICE_SECRET_KEY"
+          if [ -n "$miss" ] && echo "${SERVICE_PUBLIC_ID}" | grep -q '^dev-placeholder$' ; then miss="$miss (using placeholder)"; fi
+          if [ -n "$miss" ] && echo "${SERVICE_SECRET_KEY}" | grep -q '^dev-placeholder$' ; then miss="$miss (using placeholder)"; fi
+          if echo "${SERVICE_PUBLIC_ID}${SERVICE_SECRET_KEY}" | grep -q 'dev-placeholder'; then
+            echo "::error::Missing required secrets on protected ref:${miss}"
+            exit 1
+          fi
 
-      - name: Publish to GitHub Packages
+      - name: Configure Gradle credentials for GitHub Packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p ~/.gradle
+          {
+            echo "gpr.user=${{ github.actor }}"
+            echo "gpr.key=${GITHUB_TOKEN}"
+          } >> ~/.gradle/gradle.properties
+
+      - name: Verify Gradle entrypoint
+        id: gradle_bin
+        run: |
+          if [ -x "./gradlew" ]; then
+            echo "bin=./gradlew" >> $GITHUB_OUTPUT
+          else
+            echo "bin=gradle" >> $GITHUB_OUTPUT
+          fi
+          echo "Using $(cut -d= -f2 $GITHUB_OUTPUT)"
+
+      - name: Build (tests)
+        run: ${{ steps.gradle_bin.outputs.bin }} build --no-daemon --stacktrace --info
+
+      - name: Publish to GitHub Packages (main or tag)
         if: github.ref_type == 'tag' || github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_ACTOR: ${{ github.actor }}
-        run: gradle publish --no-daemon
+        run: ${{ steps.gradle_bin.outputs.bin }} publish --no-daemon --stacktrace --info


### PR DESCRIPTION
## Summary
- avoid failing PR builds by using placeholders for service secrets and only enforcing secret checks on main or tagged releases

## Checklist
- [x] `rg -n -F '5Wxp05N8JKM7MVCR1WW1|tufVkQvI4cyxvdtOd62YNa3Q'` → no results
- [x] `rg -n '5Wxp05N8JKM7MVCR1WW1'` → no results
- [x] `rg -n 'tufVkQvI4cyxvdtOd62YNa3Q'` → no results

## Commands
- `gradle test`

## Migration
- ensure `SERVICE_PUBLIC_ID` and `SERVICE_SECRET_KEY` are defined in your environment or CI secrets for main/tag builds; copy `.env.example` to `.env` for local development

------
https://chatgpt.com/codex/tasks/task_e_689f90d940888330a7d90d739847b1b1