### PR TITLE
Remove hardcoded token; env-based config + CI secrets

### DIFF
--- a/.ci/run_gh_workflow.sh
+++ b/.ci/run_gh_workflow.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REPO_SLUG="tylerblakex-netizen/AutoPost"
+WORKFLOW_FILE="${1:-ci.yml}"
+
+# Determine current branch (works locally and in CI)
+branch_name="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
+if [[ -z "${branch_name}" || "${branch_name}" == "HEAD" ]]; then
+  branch_name="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-}}"
+fi
+
+if [[ -z "${branch_name}" ]]; then
+  echo "⚠️  Could not determine branch name (detached HEAD?). Skipping workflow trigger."
+  exit 0
+fi
+
+echo "🔎 Using branch: ${branch_name}"
+
+# Ensure GH CLI present (non-fatal if missing)
+if ! command -v gh >/dev/null 2>&1; then
+  echo "⚠️  gh CLI not found. Install and auth to trigger workflows, or run manually:"
+  echo "    gh workflow run ${WORKFLOW_FILE} --repo ${REPO_SLUG} --ref ${branch_name}"
+  exit 0
+fi
+
+# Make sure we're authenticated
+if ! gh auth status >/dev/null 2>&1; then
+  echo "⚠️  gh not authenticated. Run: gh auth login"
+  exit 0
+fi
+
+# If the branch doesn't exist on origin, push it first
+if ! git ls-remote --exit-code --heads origin "${branch_name}" >/dev/null 2>&1; then
+  echo "⬆️  Branch '${branch_name}' not on remote. Pushing…"
+  git push -u origin "${branch_name}"
+fi
+
+# Trigger the workflow for the current branch
+set +e
+gh workflow run "${WORKFLOW_FILE}" --repo "${REPO_SLUG}" --ref "${branch_name}"
+rc=$?
+set -e
+
+if [[ $rc -ne 0 ]]; then
+  echo "⚠️  Failed to trigger workflow '${WORKFLOW_FILE}' on '${branch_name}'. Non-fatal; continuing."
+  exit 0
+fi
+
+echo "✅ Workflow '${WORKFLOW_FILE}' triggered for '${branch_name}'."

--- a/.ci/shellcheck.sh
+++ b/.ci/shellcheck.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Find all shell scripts tracked by git except gradlew and .git internals
+set +e
+mapfile -t FILES < <(git ls-files '*.sh' ':!:gradlew' ':!:.git/*')
+GIT_EC=$?
+set -e
+
+# Exit on real git error (not “no files”)
+if [[ $GIT_EC -ne 0 && $GIT_EC -ne 1 ]]; then
+  echo "git ls-files failed with exit code $GIT_EC"
+  exit $GIT_EC
+fi
+
+if (( ${#FILES[@]} == 0 )); then
+  echo "No shell scripts found. Skipping shellcheck."
+  exit 0
+fi
+
+echo "Running shellcheck on: ${FILES[*]}"
+shellcheck "${FILES[@]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI (shellcheck + Gradle)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      # Allow repositories with zero Gradle wrappers
+      - name: Validate Gradle wrapper (tolerate missing)
+        uses: gradle/actions/wrapper-validation@v3
+        with:
+          min-wrapper-count: 0
+          allow-snapshots: false
+
+      # Install tool Gradle so we can run `gradle` (no ./gradlew in repo)
+      - name: Setup Gradle 8.10.1
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.10.1
+          cache-read-only: false
+
+      - name: Ensure scripts are executable
+        run: |
+          if [ -f .ci/shellcheck.sh ]; then chmod +x .ci/shellcheck.sh; fi
+
+      - name: Install shellcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: Shellcheck
+        run: |
+          bash .ci/shellcheck.sh
+
+      # Run Gradle using the installed tool; be tolerant if extra tasks aren't present
+      - name: Gradle build
+        if: ${{ hashFiles('settings.gradle*', 'build.gradle*') != '' }}
+        env:
+          SERVICE_PUBLIC_ID: ${{ vars.SERVICE_PUBLIC_ID }}
+          SERVICE_SECRET_KEY: ${{ secrets.SERVICE_SECRET_KEY }}
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.jvmargs='-Xmx2g -XX:+UseG1GC'"
+        run: |
+          set -euo pipefail
+          gradle --version
+
+          TASKS=$(gradle -q tasks --all | sed 's/\r//')
+          HAS_SPOTLESS=0
+          HAS_JACOCO=0
+          echo "$TASKS" | grep -qE '(^| )spotlessApply( |$)' && HAS_SPOTLESS=1 || true
+          echo "$TASKS" | grep -qE '(^| )jacocoTestReport( |$)' && HAS_JACOCO=1 || true
+
+          CMD=("gradle" "--stacktrace" "--no-daemon")
+          if [ $HAS_SPOTLESS -eq 1 ]; then CMD+=("spotlessApply"); fi
+          CMD+=("build")
+          if [ $HAS_JACOCO -eq 1 ]; then CMD+=("jacocoTestReport"); fi
+
+          echo "Running: ${CMD[*]}"
+          "${CMD[@]}"


### PR DESCRIPTION
## Summary
- run shellcheck and Gradle in CI without requiring a wrapper
- add a robust `.ci/shellcheck.sh` script
- add `.ci/run_gh_workflow.sh` to auto-push current branch and trigger GitHub workflows safely

## Testing
- `bash .ci/shellcheck.sh`
- `gradle --stacktrace --no-daemon build`
- `.ci/run_gh_workflow.sh ci.yml`

## Token search checklist
- `rg --stats "5Wxp05N8JKM7MVCR1WW1|tufVkQvI4cyxvdtOd62YNa3Q"`
- `rg --stats "5Wxp05N8JKM7MVCR1WW1"`
- `rg --stats "tufVkQvI4cyxvdtOd62YNa3Q"`

## Migration
- ensure `SERVICE_PUBLIC_ID` and `SERVICE_SECRET_KEY` are provided via environment or secrets


------
https://chatgpt.com/codex/tasks/task_e_689fa0fcc7548330a6cc52d66b74e841