### PR TITLE
Remove hardcoded token; env-based config + CI secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,8 @@
-# === Public example only — DO NOT COMMIT REAL SECRETS ===
-# Copy to .env locally and fill in; in CI use GitHub Secrets, not .env.
-
-OPENAI_API_KEY=__set_in_github_secrets__
-ANTHROPIC_API_KEY=__set_in_github_secrets__
-X_API_KEY=__set_in_github_secrets__
-
-RAW_FOLDER_ID=__set_in_github_secrets__
-EDITS_FOLDER_ID=__set_in_github_secrets__
-GOOGLE_SERVICE_ACCOUNT_JSON={"type":"service_account"}  # placeholder only
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+RAW_FOLDER_ID=
+EDITS_FOLDER_ID=
+GOOGLE_SERVICE_ACCOUNT_JSON=
+X_API_KEY=
 SERVICE_PUBLIC_ID=pk_xxxxxxxxxxxxxxxxx
 SERVICE_SECRET_KEY=sk_xxxxxxxxxxxxxxxxx

--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -1,0 +1,113 @@
+name: CI • Build & Test (Maven/Gradle, 2x with retry)
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      MAVEN_OPTS: -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
+      GRADLE_OPTS: -Dorg.gradle.daemon=false
+      SERVICE_PUBLIC_ID: ${{ secrets.SERVICE_PUBLIC_ID }}
+      SERVICE_SECRET_KEY: ${{ secrets.SERVICE_SECRET_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Java 21 (Temurin)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Cache Maven
+        if: ${{ hashFiles('**/pom.xml') != '' }}
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
+      - name: Cache Gradle
+        if: ${{ hashFiles('**/build.gradle*') != '' || hashFiles('gradle/wrapper/gradle-wrapper.properties') != '' }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
+
+      - name: Make Gradle wrapper executable (if present)
+        if: ${{ hashFiles('gradlew') != '' }}
+        run: chmod +x gradlew
+
+      - name: Maven — Build & Test (run twice with one retry)
+        if: ${{ hashFiles('**/pom.xml') != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          for run in 1 2; do
+            echo "==== Maven test run #$run ===="
+            mvn -B -ntp -DskipITs=false -DfailIfNoTests=false clean test && break || {
+              if [ "$run" = "1" ]; then
+                echo "First Maven run failed — retrying once..."
+                sleep 3
+              else
+                exit 1
+              fi
+            }
+          done
+
+      - name: Gradle — Build & Test (run twice with one retry)
+        if: ${{ hashFiles('**/build.gradle*') != '' || hashFiles('gradle/wrapper/gradle-wrapper.properties') != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          for run in 1 2; do
+            echo "==== Gradle test run #$run ===="
+            if [ -f "./gradlew" ]; then
+              ./gradlew --no-daemon clean test && break || {
+                if [ "$run" = "1" ]; then
+                  echo "First Gradle run failed — retrying once..."
+                  sleep 3
+                else
+                  exit 1
+                fi
+              }
+            else
+              gradle --no-daemon clean test && break || {
+                if [ "$run" = "1" ]; then
+                  echo "First Gradle run failed — retrying once..."
+                  sleep 3
+                else
+                  exit 1
+                fi
+              }
+            fi
+          done
+
+      - name: Upload test reports (if present)
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: |
+            **/build/test-results/test/**
+            **/target/surefire-reports/**
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,21 +21,23 @@ jobs:
       RAW_FOLDER_ID: ${{ secrets.RAW_FOLDER_ID }}
       EDITS_FOLDER_ID: ${{ secrets.EDITS_FOLDER_ID }}
       GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
+      SERVICE_PUBLIC_ID: ${{ secrets.SERVICE_PUBLIC_ID }}
+      SERVICE_SECRET_KEY: ${{ secrets.SERVICE_SECRET_KEY }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Notice (SERVICE_* no longer required)
+      - name: Check service credentials
         shell: bash
         env:
-          SERVICE_PUBLIC_ID: ${{ vars.SERVICE_PUBLIC_ID }}
-          SERVICE_SECRET_KEY: ${{ vars.SERVICE_SECRET_KEY }}
+          SERVICE_PUBLIC_ID: ${{ secrets.SERVICE_PUBLIC_ID }}
+          SERVICE_SECRET_KEY: ${{ secrets.SERVICE_SECRET_KEY }}
         run: |
           if [ -z "${SERVICE_PUBLIC_ID}" ] || [ -z "${SERVICE_SECRET_KEY}" ]; then
-            echo "::notice title=Service credentials not set::Skipping any steps that need SERVICE_PUBLIC_ID / SERVICE_SECRET_KEY."
+            echo "::notice title=Service credentials not set::Skipping steps requiring SERVICE_PUBLIC_ID / SERVICE_SECRET_KEY."
           else
-            echo "Service credentials provided via repo Variables."
+            echo "Service credentials provided via secrets."
           fi
 
       - name: Set up JDK 21

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,22 @@ Thumbs.db
 
 # Logs
 *.log
+# env & secrets
+.env
+.env.local
+*.pem
+*.keystore
+
+# build outputs
+/build/
+/target/
+/.gradle/
+/.mvn/
+
+# node
+/node_modules/
+
+# IDE & OS
+.idea/
+.vscode/
+.DS_Store


### PR DESCRIPTION
## Summary
- add consolidated Maven/Gradle CI workflow with retry logic and secret-based service credentials
- document env vars via `.env.example` and lock down secrets in `.gitignore`
- wire existing CI to read `SERVICE_PUBLIC_ID`/`SERVICE_SECRET_KEY` from GitHub Secrets

## Testing
- `gradle test` *(fails: package `org.springframework.context.annotation` does not exist)*
- `rg -n "5Wxp05N8JKM7MVCR1WW1|tufVkQvI4cyxvdtOd62YNa3Q" -F`
- `rg -n "5Wxp05N8JKM7MVCR1WW1"`
- `rg -n "tufVkQvI4cyxvdtOd62YNa3Q"`


------
https://chatgpt.com/codex/tasks/task_e_689fc3f2aa3c8330845b1123695e15a9